### PR TITLE
fix: used different plugin for NPM

### DIFF
--- a/.github/workflows/codeartifact.yml
+++ b/.github/workflows/codeartifact.yml
@@ -15,6 +15,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: cycjimmy/semantic-release-action@v4
         id: semantic
+        with:
+          extra_plugins: |
+            @semantic-release/exec
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
I merged the PR to add code artifact deploy and the github action failed because this repo does not have package.json file and I did some digging and came across this https://github.com/semantic-release/semantic-release/issues/738#issuecomment-380122681 and then looked into https://github.com/marketplace/actions/action-for-semantic-release, more specifically the section of
```
steps:
  - name: Checkout
    uses: actions/checkout@v4
  - name: Semantic Release
    uses: cycjimmy/semantic-release-action@v4
    with:
      # You can extend an existing shareable configuration.
      # And you can specify version range for the shareable configuration if you prefer.
      extends: |
        @semantic-release/apm-config@^9.0.0
        @mycompany/override-config
    env:
      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
```
     
      and I think it will work. Please have a look and let me 